### PR TITLE
Apply plugin development guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.4.0
+  - 2.3.3
   - 2.2
   - 2.1
-  - 2.0.0
+
 before_install:
   - gem install bundler

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,6 @@ require 'bundler/gem_tasks'
 
 require 'rake/testtask'
 require 'rake/clean'
-require 'rspec/core/rake_task'
-
-RSpec::Core::RakeTask.new(:spec)
 
 desc 'Run test_unit based test'
 Rake::TestTask.new(:test) do |t|
@@ -23,4 +20,4 @@ task :coverage do |t|
   Rake::Task["test"].invoke
 end
 
-task :default => [:test, :spec, :build]
+task :default => [:test, :build]

--- a/fluent-plugin-newsyslog.gemspec
+++ b/fluent-plugin-newsyslog.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fluentd', '>= 0.10.59'
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'flexmock'
   spec.add_development_dependency 'simplecov', '~> 0.6.4'
   spec.add_development_dependency 'rr', '>= 1.0.0'

--- a/lib/fluent/plugin/in_newsyslog.rb
+++ b/lib/fluent/plugin/in_newsyslog.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class NewSyslogInput < Input
     Plugin.register_input('newsyslog', self)
@@ -72,6 +74,8 @@ module Fluent
     end
 
     def start
+      super
+
       @loop = Coolio::Loop.new
       @handler = listen(method(:receive_data))
       @loop.attach(@handler)
@@ -84,6 +88,8 @@ module Fluent
       @loop.stop
       @handler.close
       @thread.join
+
+      super
     end
 
     def run

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -56,5 +56,3 @@ def ipv6_enabled?
     false
   end
 end
-
-$log = Fluent::Log.new(Fluent::Test::DummyLogDevice.new, Fluent::Log::LEVEL_WARN)


### PR DESCRIPTION
Without `require 'fluent/input'`, recent fluentd raises an error.